### PR TITLE
scheduleMatches is broken for Sunday

### DIFF
--- a/cron.cabal
+++ b/cron.cabal
@@ -50,7 +50,7 @@ test-suite spec
                   cron,
                   hspec == 1.3.*,
                   hspec-expectations,
-                  attoparsec      == 0.10.*,
+                  attoparsec      >= 0.10,
                   text            >= 0.11 && < 2,
                   time            >= 1.4
 

--- a/test/System/Cron/ParserSpec.hs
+++ b/test/System/Cron/ParserSpec.hs
@@ -79,6 +79,12 @@ describeCronSchedule = describe "cronSchedule" $ do
   it "parses steps at the last field" $
     assertSuccessfulParse "* * * * */4"
                            stars { dayOfWeek  = DaysOfWeek (StepField Star 4) }
+  it "parses a sunday as 7" $
+    assertSuccessfulParse "* * * * 7"
+                           stars { dayOfWeek  = DaysOfWeek (SpecificField 7) }
+  it "parses a sunday as 0" $
+    assertSuccessfulParse "* * * * 0"
+                           stars { dayOfWeek  = DaysOfWeek (SpecificField 0) }
   where assertSuccessfulParse = assertParse cronSchedule
         assertFailedParse = assertNoParse cronSchedule 
 

--- a/test/System/CronSpec.hs
+++ b/test/System/CronSpec.hs
@@ -57,6 +57,16 @@ describeScheduleMatches = describe "ScheduleMatches" $ do
                             dayOfMonth = DaysOfMonth (SpecificField 3),
                             hour       = Hours (RangeField 10 14) }
                     (day 5 3 13 2)
+  it "matches a monday as 1" $
+    scheduleMatches stars { dayOfWeek  = DaysOfWeek (SpecificField 1) }
+                    (UTCTime (fromGregorian 2014 3 17) 0)
+  it "matches a sunday as 0" $
+    scheduleMatches stars { dayOfWeek  = DaysOfWeek (SpecificField 0) }
+                    (UTCTime (fromGregorian 2014 3 16) 0)
+  it "matches a sunday as 7" $
+    scheduleMatches stars { dayOfWeek  = DaysOfWeek (SpecificField 7) }
+                    (UTCTime (fromGregorian 2014 3 16) 0)
+
   where day m d h mn = UTCTime (fromGregorian 2012 m d) (diffTime h mn)
         diffTime h mn = timeOfDayToTime $ TimeOfDay h mn 0
 


### PR DESCRIPTION
http://www.unix.com/man-page/linux/5/crontab/ says: "When specifying day of week, both day 0 and day 7 will be considered Sunday"

However, `scheduleMatches` does not comply. Added a test case and will try to commit a fix tomorrow.
