### PR TITLE
Fix syntax error on front-page of docs

### DIFF
--- a/src/System/Cron.hs
+++ b/src/System/Cron.hs
@@ -17,14 +17,13 @@
 -- > import System.Cron
 -- >
 -- > main :: IO ()
--- > main = do
--- >   forever do
--- >     now <- getCurrentTime
--- >     when (scheduleMatches schedule now) doWork
--- >     putStrLn "sleeping"
--- >     threadDelay 100000
--- >   where doWork   = putStrLn "Time to work"
--- >         schedule = hourly
+-- > main = forever $ do
+-- >          now <- getCurrentTime
+-- >          when (scheduleMatches schedule now) doWork
+-- >          putStrLn "sleeping"
+-- >          threadDelay 100000
+-- >        where doWork   = putStrLn "Time to work"
+-- >              schedule = hourly
 --
 --------------------------------------------------------------------
 module System.Cron (CronSchedule(..),


### PR DESCRIPTION
I was trying out https://hackage.haskell.org/package/cron-0.2.1/docs/System-Cron.html, installed the library, pasted in the code and got:

``` haskell
import Control.Concurrent
import Control.Monad
import Data.Time.Clock
import System.Cron

main :: IO ()
main = do
  forever do
    now <- getCurrentTime
    when (scheduleMatches schedule now) doWork
    putStrLn "sleeping"
    threadDelay 100000
  where doWork   = putStrLn "Time to work"
        schedule = hourly

-- Syntax error:
-- Main.hs:8:11: parse error on input `do'
-- [nix-shell:~/programming/haskell/cron-test]$ ghc --version
-- The Glorious Glasgow Haskell Compilation System, version 7.6.3
```

This fixes the simple syntax error.
