### PR TITLE
Stop a single exception from killing a whole cron thread

### DIFF
--- a/src/System/Cron/Schedule.hs
+++ b/src/System/Cron/Schedule.hs
@@ -103,12 +103,22 @@ instance (Monad m) => MonadSchedule (ScheduleT m) where
 
 {- Monitoring Engine -}
 
+-- | Schedule all of the jobs to run at appropriate intervals. Each 
+-- job that is launched gets a scheduling thread to itself. Each 
+-- time a scheduling thread launches a job, the job is forked onto
+-- a new thread. This means that if a job throws an excpetion in IO,
+-- its thread will be killed, but it will continue to be scheduled 
+-- in the future.
 execSchedule :: Schedule () -> IO [ThreadId]
 execSchedule s = let res = runSchedule s
                   in case res of
                         Left  e         -> print e >> return []
                         Right (_, jobs) -> mapM forkJob jobs
 
+-- | Start a job-runner thread that runs a job at appropriate 
+-- intervals. Each time it is run, a new thread is forked for it,
+-- meaning that a single exception does not take down the
+-- scheduler.
 forkJob :: Job -> IO ThreadId
 forkJob (Job s a) = forkIO $ forever $ do
             (timeAt, delay) <- findNextMinuteDelay

--- a/src/System/Cron/Schedule.hs
+++ b/src/System/Cron/Schedule.hs
@@ -113,7 +113,7 @@ forkJob :: Job -> IO ThreadId
 forkJob (Job s a) = forkIO $ forever $ do
             (timeAt, delay) <- findNextMinuteDelay
             threadDelay delay
-            when (scheduleMatches s timeAt) a
+            when (scheduleMatches s timeAt) (void $ forkIO a)
 
 findNextMinuteDelay :: IO (UTCTime, Int)
 findNextMinuteDelay = do


### PR DESCRIPTION
At present, if a cron job does something that causes it to throw an exception in IO (like making an API call to a web server that happens to be down), the whole thread gets killed. This means that the job quits running until the application is restarted. This PR prevents that behavior from occurring.