### PR TITLE
Raises upper bound on text (<3)

### DIFF
--- a/cron.cabal
+++ b/cron.cabal
@@ -58,7 +58,7 @@ library
   default-language:    Haskell2010
   build-depends:     base            >= 4 && < 5
                    , attoparsec      >= 0.10
-                   , text            >= 0.11 && < 2
+                   , text            >= 0.11 && < 3
                    , time            >= 1.4
                    , old-locale      >= 1.0
                    , mtl             >= 2.0.1


### PR DESCRIPTION
Just what it says on the tin: `text-2.0` is out.