### PR TITLE
Add `MonadTrans` instance to ScheduleT

### DIFF
--- a/src/System/Cron/Schedule.hs
+++ b/src/System/Cron/Schedule.hs
@@ -41,6 +41,7 @@ module System.Cron.Schedule
     , runScheduleT
 
     , execSchedule
+    , jobsToSchedule
     ) where
 
 
@@ -93,6 +94,8 @@ newtype ScheduleT m a = ScheduleT { unSchedule :: StateT Jobs (ExceptT ScheduleE
                  , MonadError ScheduleError
                  )
 
+instance MonadTrans ScheduleT where
+    lift = ScheduleT . lift . lift
 
 -------------------------------------------------------------------------------
 runSchedule :: Schedule a -> Either ScheduleError (a, [Job])
@@ -119,6 +122,10 @@ instance (Monad m) => MonadSchedule (ScheduleT m) where
 -- Monitoring engine
 -------------------------------------------------------------------------------
 
+-- | Utility function to initialize a schedule from a set of jobs.
+jobsToSchedule :: [Job] -> Schedule ()
+jobsToSchedule jobs = forM_ jobs $ \(Job schedule action) -> do
+    addJob action (serializeCronSchedule schedule)
 
 -- | Schedule all of the jobs to run at appropriate intervals. Each
 -- job that is launched gets a scheduling thread to itself. Each


### PR DESCRIPTION
Makes it more convenient to use within a transformers stack.