### PR TITLE
Expose fork job

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+# 0.7.1
+* expose fork job, Jappie Klooster (@jappeace)
 # 0.7.0
 * Fix time parsing error (#41), Julien Debon (@Sir4ur0n)
 # 0.6.2

--- a/cron.cabal
+++ b/cron.cabal
@@ -1,5 +1,5 @@
 Name:                cron
-Version:             0.7.0
+Version:             0.7.1
 Description:
   Cron data structure and Attoparsec parser. The idea is to embed it in larger
   systems which want to roll their own scheduled tasks in a format that people

--- a/src/System/Cron/Schedule.hs
+++ b/src/System/Cron/Schedule.hs
@@ -31,6 +31,7 @@
 
 module System.Cron.Schedule
     ( Job (..)
+    , forkJob
     , ScheduleError (..)
     , Schedule
     , ScheduleT (..)


### PR DESCRIPTION
It doesn't make sense to expose 'runSchedule'
and 'runScheduleT' without exposing 'forkJob'.
I'd like to log an error on schedule errors,
the default implementation doesn't allow me
to do that.